### PR TITLE
Add required xero source models and macros for purchase orders and purchase order line items

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'xero_source'
-version: '0.4.0'
+version: '0.3.0'
 config-version: 2
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: ">=0.20.0"
 
 vars:
   xero_source:
@@ -14,6 +14,8 @@ vars:
     organization: "{{ source('xero','organization') }}"
     bank_transaction: "{{ source('xero','bank_transaction') }}"
     credit_note: "{{ source('xero','credit_note') }}"
+    purchase_order: "{{ source('xero','purchase_order') }}"
+    purchase_order_line_item: "{{ source('xero','purchase_order_line_item') }}"
 
 models:
   xero_source:

--- a/macros/get_purchase_order_columns.sql
+++ b/macros/get_purchase_order_columns.sql
@@ -1,0 +1,30 @@
+{% macro get_purchase_order_columns() %}
+
+{% set columns = [
+    {"name": "_fivetran_synced", "datatype": dbt_utils.type_timestamp()},
+    {"name": "branding_theme_id", "datatype": dbt_utils.type_string()},
+    {"name": "type", "datatype": dbt_utils.type_string()},
+    {"name": "contact_id", "datatype": dbt_utils.type_string()},
+    {"name": "currency_code", "datatype": dbt_utils.type_string()},
+    {"name": "currency_rate", "datatype": dbt_utils.type_numeric()},
+    {"name": "date", "datatype": "date"},
+    {"name": "delivery_date", "datatype": "date"},
+    {"name": "purchase_order_id", "datatype": dbt_utils.type_string()},
+    {"name": "purchase_order_number", "datatype": dbt_utils.type_string()},
+    {"name": "is_discounted", "datatype": "boolean"},
+    {"name": "reference", "datatype": dbt_utils.type_string()},
+    {"name": "status", "datatype": dbt_utils.type_string()},
+    {"name": "sub_total", "datatype": dbt_utils.type_numeric()},
+    {"name": "total", "datatype": dbt_utils.type_numeric()},
+    {"name": "total_tax", "datatype": dbt_utils.type_numeric()},
+    {"name": "line_amount_types", "datatype": dbt_utils.type_string()},
+    {"name": "delivery_address", "datatype": dbt_utils.type_string()},
+    {"name": "attention_to", "datatype": dbt_utils.type_string()},
+    {"name": "telephone", "datatype": dbt_utils.type_string()},
+    {"name": "delivery_instructions", "datatype": dbt_utils.type_string()},
+    {"name": "updated_date_utc", "datatype": dbt_utils.type_timestamp()}
+] %}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/macros/get_purchase_order_line_item_columns.sql
+++ b/macros/get_purchase_order_line_item_columns.sql
@@ -1,0 +1,20 @@
+{% macro get_purchase_order_line_item_columns() %}
+
+{% set columns = [
+    {"name": "_fivetran_synced", "datatype": dbt_utils.type_timestamp()},
+    {"name": "account_code", "datatype": dbt_utils.type_string()},
+    {"name": "description", "datatype": dbt_utils.type_string()},
+    {"name": "discount_rate", "datatype": dbt_utils.type_int()},
+    {"name": "purchase_order_id", "datatype": dbt_utils.type_string()},
+    {"name": "item_code", "datatype": dbt_utils.type_string()},
+    {"name": "line_amount", "datatype": dbt_utils.type_numeric()},
+    {"name": "line_item_id", "datatype": dbt_utils.type_string()},
+    {"name": "quantity", "datatype": dbt_utils.type_numeric()},
+    {"name": "tax_amount", "datatype": dbt_utils.type_numeric()},
+    {"name": "tax_type", "datatype": dbt_utils.type_string()},
+    {"name": "unit_amount", "datatype": dbt_utils.type_numeric()}
+] %}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/models/src_xero.yml
+++ b/models/src_xero.yml
@@ -170,3 +170,79 @@ sources:
             description: Xero identifier for the credit note.
           - name: contact_id
             description: The ID of the associated contact in Xero
+
+      - name: purchase_order_line_item
+        description: Each record in this table represents a purchase order line item in Xero.
+        columns:
+          - name: _fivetran_synced
+            description: "{{ doc('_fivetran_synced') }}"
+          - name: account_code
+            description: Customer defined alpha numeric account code e.g 200 or SALES
+          - name: description
+            description: The description of the line item
+          - name: discount_rate
+            description: Percentage discount being applied to a purchase order line item.
+          - name: purchase_order_id
+            description: The Xero identifier for the purchase order the line items belongs to.
+          - name: item_code
+            description: User defined item code.
+          - name: line_amount
+            description: The line amount reflects the discounted price if a DiscountRate has been used.
+          - name: line_item_id
+            description: Xero identifier for the purchase order line item.
+          - name: quantity
+            description: The quantity of the purchase order line item.
+          - name: tax_amount
+            description: The tax amount is auto calculated as a percentage of the line amount based on the tax rate.
+          - name: tax_type
+            description: Used as an override if the default Tax Code for the selected AccountCode is not correct.
+          - name: unit_amount
+            description: The unit amount of each purchase order line item. 
+
+      - name: purchase_order
+        description: Each record in this table represents a purchase order in Xero.
+        columns:
+          - name: purchase_order_id
+            description: Xero identifier for the purchase order
+          - name: purchase_order_number
+            description: Alpha numeric code identifying the purchase order, typically a sequential number
+          - name: contact_id
+            description: The Xero identifier for the associated contact.
+          - name: date
+            description: The date the purchase order was issued.
+          - name: updated_date_utc
+            description: The date the purchase order was last modified.
+          - name: delivery_date
+            description: The expected delivery date of the purchase order goods, when set.
+          - name: _fivetran_synced
+            description: "{{ doc('_fivetran_synced') }}"
+          - name: currency_code
+            description: The currency that purchase order has been raised in
+          - name: currency_rate
+            description: The currency rate for a multicurrency purchase order
+          - name: reference
+            description: Additional reference number to suit the organisation or supplier.
+          - name: status
+            description: The status of the purchase order
+          - name: type
+            description: The type of the purchase order.
+          - name: delivery_address
+            description: Address details for delivery of the purchase order goods
+          - name: attention_to
+            description: The name of the person who will receive the goods
+          - name: telephone
+            description: The contact number of the person who will receive the goods
+          - name: delivery_instructions
+            description: Delivery instructions where required
+          - name: is_discounted
+            description: Flags if purchase order items have discounts applied
+          - name: branding_theme_id
+            description: Populated if a template has been applied to the purchase order to customise its appearance
+          - name: line_amount_types
+            description: Tax inclusive, exclusive or no tax
+          - name: sub_total
+            description: Purchase order amount before tax
+          - name: total_tax
+            description: Purchase order tax amount
+          - name: total
+            description: Purchase order total amount including tax

--- a/models/stg_xero.yml
+++ b/models/stg_xero.yml
@@ -235,3 +235,98 @@ models:
           The source where this data was pulled from. If you are making use of the `union_schemas` variable, this will be the source schema.
           If you are making use of the `union_databases` variable, this will be the source database. If you are not unioining together multiple
           sources, this will be an empty string.
+
+
+  - name: stg_xero__purchase_order_line_item
+    description: Each record in this table represents a purchase order line item in Xero.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - purchase_order_id
+            - line_item_id
+            - source_relation  
+    columns:
+      - name: _fivetran_synced
+        description: "{{ doc('_fivetran_synced') }}"
+      - name: account_code
+        description: Customer defined alpha numeric account code e.g 200 or SALES
+      - name: description
+        description: The description of the line item
+      - name: discount_rate
+        description: Percentage discount being applied to a purchase order line item.
+      - name: purchase_order_id
+        description: The Xero identifier for the purchase order the line items belongs to.
+        tests:
+          - not_null
+      - name: item_code
+        description: User defined item code.
+      - name: line_amount
+        description: The line amount reflects the discounted price if a DiscountRate has been used.
+      - name: line_item_id
+        description: Xero identifier for the purchase order line item.
+        tests:
+          - not_null
+      - name: quantity
+        description: The quantity of the purchase order line item.
+      - name: tax_amount
+        description: The tax amount is auto calculated as a percentage of the line amount based on the tax rate.
+      - name: tax_type
+        description: Used as an override if the default Tax Code for the selected AccountCode is not correct.
+      - name: unit_amount
+        description: The unit amount of each purchase order line item.
+      - name: source_relation
+        description: >
+          The source where this data was pulled from. If you are making use of the `union_schemas` variable, this will be the source schema.
+          If you are making use of the `union_databases` variable, this will be the source database. If you are not unioining together multiple
+          sources, this will be an empty string.
+
+  - name: stg_xero__purchase_order
+    description: Each record in this table represents a purchase order in Xero.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - purchase_order_id
+            - source_relation  
+    columns:
+      - name: purchase_order_id
+        description: Xero identifier for the purchase order
+        tests:
+          - not_null
+      - name: purchase_order_number
+        description: Alpha numeric code identifying the purchase order, typically a sequential number
+      - name: contact_id
+        description: The Xero identifier for the associated contact.
+      - name: purchase_order_date
+        description: The date the purchase order was issued.
+      - name: updated_date
+        description: The date the purchase order was last modified.
+      - name: delivery_date
+        description: The expected delivery date of the purchase order goods, when set.
+      - name: _fivetran_synced
+        description: "{{ doc('_fivetran_synced') }}"
+      - name: currency_code
+        description: The currency that purchase order has been raised in
+      - name: currency_rate
+        description: The currency rate for a multicurrency purchase order
+      - name: reference
+        description: Additional reference number to suit the organisation or supplier.
+      - name: status
+        description: The status of the purchase order
+      - name: type
+        description: The type of the purchase order.
+      - name: is_discounted
+        description: Flags if purchase order items have discounts applied
+      - name: line_amount_types
+        description: Tax inclusive, exclusive or no tax
+      - name: sub_total
+        description: Purchase order amount before tax
+      - name: total_tax
+        description: Purchase order tax amount
+      - name: total
+        description: Purchase order total amount including tax
+      - name: source_relation
+        description: >
+          The source where this data was pulled from. If you are making use of the `union_schemas` variable, this will be the source schema.
+          If you are making use of the `union_databases` variable, this will be the source database. If you are not unioining together multiple
+          sources, this will be an empty string.
+

--- a/models/stg_xero__purchase_order.sql
+++ b/models/stg_xero__purchase_order.sql
@@ -1,0 +1,53 @@
+
+with base as (
+
+    select * 
+    from {{ ref('stg_xero__purchase_order_tmp') }}
+
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_xero__purchase_order_tmp')),
+                staging_columns=get_purchase_order_columns()
+            )
+        }}
+        
+        {{ fivetran_utils.add_dbt_source_relation() }}
+    from base
+),
+
+final as (
+    
+    select 
+        -- IDs
+        purchase_order_id,
+        contact_id,
+
+        -- dates
+        date as purchase_order_date,
+        updated_date_utc as updated_date,
+        delivery_date,
+        _fivetran_synced,
+
+        sub_total,
+        total_tax,
+        total,
+        currency_code,
+        currency_rate,
+        purchase_order_number,
+        reference,
+        status as purchase_order_status,
+        type,
+        is_discounted,
+        line_amount_types
+
+        {{ fivetran_utils.source_relation() }}
+        
+    from fields
+)
+
+select * from final

--- a/models/stg_xero__purchase_order_line_item.sql
+++ b/models/stg_xero__purchase_order_line_item.sql
@@ -1,0 +1,45 @@
+
+with base as (
+
+    select * 
+    from {{ ref('stg_xero__purchase_order_line_item_tmp') }}
+
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_xero__purchase_order_line_item_tmp')),
+                staging_columns=get_purchase_order_line_item_columns()
+            )
+        }}
+
+        {{ fivetran_utils.add_dbt_source_relation() }}    
+    from base
+),
+
+final as (
+    
+    select 
+        _fivetran_synced,
+        account_code,
+        description as line_item_description,
+        discount_rate,
+        purchase_order_id,
+        item_code,
+        line_amount,
+        line_item_id,
+        quantity,
+        tax_amount,
+        tax_type,
+        unit_amount
+
+        {{ fivetran_utils.source_relation() }}
+        
+    from fields
+)
+
+select * from final
+

--- a/models/tmp/stg_xero__purchase_order_line_item_tmp.sql
+++ b/models/tmp/stg_xero__purchase_order_line_item_tmp.sql
@@ -1,0 +1,10 @@
+{{
+    fivetran_utils.union_data(
+        table_identifier='purchase_order_line_item', 
+        database_variable='xero_database', 
+        schema_variable='xero_schema', 
+        default_database=target.database,
+        default_schema='xero',
+        default_variable='purchase_order_line_item'
+    )
+}} 

--- a/models/tmp/stg_xero__purchase_order_tmp.sql
+++ b/models/tmp/stg_xero__purchase_order_tmp.sql
@@ -1,0 +1,10 @@
+{{
+    fivetran_utils.union_data(
+        table_identifier='purchase_order', 
+        database_variable='xero_database', 
+        schema_variable='xero_schema', 
+        default_database=target.database,
+        default_schema='xero',
+        default_variable='purchase_order'
+    )
+}} 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
 - package: fivetran/fivetran_utils
-  version: [">=0.3.0", "<0.4.0"]
+  version: [">=0.2.0", "<0.3.0"]


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Doug Jeffery, Modulous

**What change(s) does this PR introduce?** 
Adds required source models and macros for Xero purchase orders and purchase order line items. These models are then used to create a purchase order model for a reporting structure in the xero package

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  - New models only, existing models are untouched

**Is this PR in response to a previously created Issue**
- [x] Yes, Issue https://github.com/fivetran/dbt_xero/issues/21 - note the issue was raised for xero package, not xero source but obviously xero source is a dependency
- [ ] No 

**How did you test the PR changes?** 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other Using Fivetran transformations against our live Xero synch, manual tests in SQL to validate the volume and contents of the source tables versus the raw data

**Select which warehouse(s) were used to test the PR**
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
:sunglasses:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
